### PR TITLE
Error in link path for "unified data model"

### DIFF
--- a/docs/source/getting-started/database.rst
+++ b/docs/source/getting-started/database.rst
@@ -1,7 +1,7 @@
-Database setup
+Database Setup
 ===============
 
-One of the reasons that Augur is so powerful is because of its `unified data model <../schema/data-model.html>`_.
+One of the reasons that Augur is so powerful is because of its `unified data model <../schema/data-model.html>`_. 
 In order to ensure this data model remains performant with large amounts of data, we use PostgreSQL as our database engine. 
 We'll need to set up a PostgreSQL instance and create a database, after which Augur can take care of the rest.
 Make sure to save off the credentials you use when you create the database, you'll need them again to configure Augur.


### PR DESCRIPTION
The link for "unified data model" throws an error, and I can't find it in the Augur files to update it. Could this be the intended link <../schema/overview.rst> ?

Also changed Database Setup title with an uppercase s.

# Pull Request Template
![screen](https://user-images.githubusercontent.com/83814427/160449133-1d32f4df-736b-431f-9695-ccdd882ed1f5.jpg)
![error](https://user-images.githubusercontent.com/83814427/160449147-8669f927-505f-4d09-a957-3cfbd7f7a726.jpg)

