### PR TITLE
"unified data model" url error

### DIFF
--- a/docs/source/getting-started/database.rst
+++ b/docs/source/getting-started/database.rst
@@ -1,7 +1,7 @@
 Database setup
 ===============
 
-One of the reasons that Augur is so powerful is because of its `unified data model <../schema/data-model.html>`_.
+One of the reasons that Augur is so powerful is because of its `unified data model <../schema/overview.rst>`_.
 In order to ensure this data model remains performant with large amounts of data, we use PostgreSQL as our database engine. 
 We'll need to set up a PostgreSQL instance and create a database, after which Augur can take care of the rest.
 Make sure to save off the credentials you use when you create the database, you'll need them again to configure Augur.


### PR DESCRIPTION
The url for "unified data model" throws an error, and I can't find it in the Augur files to update it. Could this be the intended link <../schema/overview.rst> ?

# Pull Request Template
![error](https://user-images.githubusercontent.com/83814427/160482220-2b2acef7-eb51-4169-a1bc-87cbee79ad98.jpg)
![screen](https://user-images.githubusercontent.com/83814427/160482237-1173fd6e-a6a8-4f2f-9169-5b9325889246.jpg)

